### PR TITLE
Rebrand UI to getcleaninbox.xyz

### DIFF
--- a/src/app/cleaner/components/Shell.tsx
+++ b/src/app/cleaner/components/Shell.tsx
@@ -17,7 +17,7 @@ export default function Shell({ children, onDisconnect, gmailConnected }: ShellP
     <div className={styles.root}>
       <nav className={styles.nav}>
         <Link href="/" className={styles.logo}>
-          clean<span>inbox</span>.ai
+          get<span>cleaninbox</span>.xyz
         </Link>
         <div className={styles.navActions}>
           {gmailConnected && (

--- a/src/app/cleaner/page.tsx
+++ b/src/app/cleaner/page.tsx
@@ -1270,7 +1270,7 @@ export default function CleanerPage() {
         <div className={styles.modalOverlay} onClick={() => setShowWelcome(false)}>
           <div className={styles.modal} onClick={e => e.stopPropagation()}>
             <p className={styles.modalTag}>// welcome</p>
-            <h2 className={styles.modalTitle}>Welcome to CleanInbox.ai</h2>
+            <h2 className={styles.modalTitle}>Welcome to GetCleanInbox</h2>
             <p className={styles.modalSub}>Here is how it works in 3 steps:</p>
             <ol style={{ margin: '8px 0 16px 0', paddingLeft: 20, fontSize: 14, lineHeight: 2 }}>
               <li><strong style={{ color: '#00d97e' }}>Connect Gmail</strong> — grant inbox access (separate from your login)</li>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ const syne = Syne({
 });
 
 export const metadata = {
-  title: 'CleanInbox AI',
+  title: 'GetCleanInbox',
   description: 'AI-powered inbox cleaner. Bulk unsubscribe and delete newsletters in one click.',
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -581,7 +581,7 @@ export default function LandingPage() {
       <div className="lp-root">
         {/* ── Nav ── */}
         <nav className="lp-nav">
-          <Link href="/" className="lp-logo">clean<span>inbox</span>.ai</Link>
+          <Link href="/" className="lp-logo">get<span>cleaninbox</span>.xyz</Link>
           <Link href="/cleaner" className="lp-nav-cta">LAUNCH APP →</Link>
         </nav>
 
@@ -804,7 +804,7 @@ export default function LandingPage() {
         <footer className="lp-footer">
           <span className="lp-footer-copy">© 2026 CLEANINBOX.AI — POWERED BY GEMINI + VERCEL AI SDK</span>
           <Link href="/cleaner" className="lp-logo" style={{fontSize:'0.75rem'}}>
-            clean<span>inbox</span>.ai
+            get<span>cleaninbox</span>.xyz
           </Link>
         </footer>
       </div>

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -54,7 +54,7 @@ export default function SignInPage() {
 
       <div className="auth-root">
         <Link href="/" className="auth-logo">
-          clean<span>inbox</span>.ai
+          get<span>cleaninbox</span>.xyz
         </Link>
         <p className="auth-tagline">// AI-powered Gmail cleaner</p>
 

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -54,7 +54,7 @@ export default function SignUpPage() {
 
       <div className="auth-root">
         <Link href="/" className="auth-logo">
-          clean<span>inbox</span>.ai
+          get<span>cleaninbox</span>.xyz
         </Link>
         <p className="auth-tagline">// AI-powered Gmail cleaner</p>
 


### PR DESCRIPTION
Update all brand name references from cleaninbox.ai to getcleaninbox.xyz to match the actual production domain. Affects nav logo, sign-in, sign-up, app shell, landing page, and welcome modal.