### PR TITLE
Fix Gmail OAuth: add CSRF state param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.59.1",
         "@types/bootstrap": "^5.2.10",
         "@types/micro": "^7.3.7",
         "@types/node": "^20",
@@ -2369,6 +2370,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7506,6 +7523,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.59.1",
     "@types/bootstrap": "^5.2.10",
     "@types/micro": "^7.3.7",
     "@types/node": "^20",

--- a/src/app/api/auth/gmail-connect/route.ts
+++ b/src/app/api/auth/gmail-connect/route.ts
@@ -1,9 +1,22 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { buildGmailAuthUrl } from '@/services/auth';
+import { randomBytes } from 'crypto';
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.redirect('/sign-in');
-  return NextResponse.redirect(buildGmailAuthUrl());
+
+  const state = randomBytes(16).toString('hex');
+  const url = buildGmailAuthUrl(state);
+
+  const res = NextResponse.redirect(url);
+  res.cookies.set('gmail_oauth_state', state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  });
+  return res;
 }

--- a/src/app/api/oauth2callback/route.ts
+++ b/src/app/api/oauth2callback/route.ts
@@ -9,10 +9,17 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(new URL('/sign-in', req.url));
   }
 
-  const code = new URL(req.url).searchParams.get('code');
+  const searchParams = new URL(req.url).searchParams;
+  const code = searchParams.get('code');
+  const returnedState = searchParams.get('state');
+  const storedState = req.cookies.get('gmail_oauth_state')?.value;
 
   if (!code) {
     return NextResponse.redirect(new URL('/cleaner?error=no_code', req.url));
+  }
+
+  if (!storedState || returnedState !== storedState) {
+    return NextResponse.redirect(new URL('/cleaner?error=invalid_state', req.url));
   }
 
   const tokens = await exchangeCodeForTokens(code);
@@ -29,5 +36,7 @@ export async function GET(req: NextRequest) {
   });
 
   console.log('Gmail tokens stored for Clerk user.');
-  return NextResponse.redirect(new URL('/cleaner', req.url));
+  const redirect = NextResponse.redirect(new URL('/cleaner', req.url));
+  redirect.cookies.delete('gmail_oauth_state');
+  return redirect;
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -51,7 +51,7 @@ export async function isGmailConnected(userId: string): Promise<boolean> {
   return !!tokenRecord?.accessToken;
 }
 
-export function buildGmailAuthUrl(): string {
+export function buildGmailAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID!,
     redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
@@ -62,6 +62,7 @@ export function buildGmailAuthUrl(): string {
     ].join(' '),
     access_type: 'offline',
     prompt: 'consent',
+    state,
   });
   return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- Adds a random `state` cookie to the Gmail OAuth flow
- Verifies state in the callback to satisfy Google's secure-response-handling policy
- Fixes the 400 error blocking Gmail connection on production

## Test plan
- [ ] Click "Connect Gmail" on getcleaninbox.xyz — should complete without 400 error