### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.59.1",
         "@types/bootstrap": "^5.2.10",
         "@types/micro": "^7.3.7",
         "@types/node": "^20",
@@ -2369,6 +2370,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7506,6 +7523,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.59.1",
     "@types/bootstrap": "^5.2.10",
     "@types/micro": "^7.3.7",
     "@types/node": "^20",

--- a/src/app/api/auth/gmail-connect/route.ts
+++ b/src/app/api/auth/gmail-connect/route.ts
@@ -1,9 +1,22 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { buildGmailAuthUrl } from '@/services/auth';
+import { randomBytes } from 'crypto';
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.redirect('/sign-in');
-  return NextResponse.redirect(buildGmailAuthUrl());
+
+  const state = randomBytes(16).toString('hex');
+  const url = buildGmailAuthUrl(state);
+
+  const res = NextResponse.redirect(url);
+  res.cookies.set('gmail_oauth_state', state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  });
+  return res;
 }

--- a/src/app/api/oauth2callback/route.ts
+++ b/src/app/api/oauth2callback/route.ts
@@ -9,10 +9,17 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(new URL('/sign-in', req.url));
   }
 
-  const code = new URL(req.url).searchParams.get('code');
+  const searchParams = new URL(req.url).searchParams;
+  const code = searchParams.get('code');
+  const returnedState = searchParams.get('state');
+  const storedState = req.cookies.get('gmail_oauth_state')?.value;
 
   if (!code) {
     return NextResponse.redirect(new URL('/cleaner?error=no_code', req.url));
+  }
+
+  if (!storedState || returnedState !== storedState) {
+    return NextResponse.redirect(new URL('/cleaner?error=invalid_state', req.url));
   }
 
   const tokens = await exchangeCodeForTokens(code);
@@ -29,5 +36,7 @@ export async function GET(req: NextRequest) {
   });
 
   console.log('Gmail tokens stored for Clerk user.');
-  return NextResponse.redirect(new URL('/cleaner', req.url));
+  const redirect = NextResponse.redirect(new URL('/cleaner', req.url));
+  redirect.cookies.delete('gmail_oauth_state');
+  return redirect;
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,145 @@
+export const metadata = {
+  title: 'Privacy Policy — GetCleanInbox',
+};
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <style>{`
+        .legal-root {
+          background: #06090f;
+          min-height: 100vh;
+          color: #c8d8cc;
+          font-family: var(--font-space-mono), monospace;
+          padding: 4rem 1.5rem;
+        }
+        .legal-wrap {
+          max-width: 720px;
+          margin: 0 auto;
+        }
+        .legal-logo {
+          font-size: 1rem;
+          color: #00d97e;
+          text-decoration: none;
+          letter-spacing: 0.05em;
+          display: inline-block;
+          margin-bottom: 2.5rem;
+        }
+        .legal-logo span { color: #c8d8cc; }
+        .legal-root h1 {
+          font-family: var(--font-syne), sans-serif;
+          font-size: 1.8rem;
+          font-weight: 700;
+          color: #f0f7f2;
+          margin-bottom: 0.5rem;
+        }
+        .legal-date {
+          font-size: 0.7rem;
+          color: #4a6a54;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          margin-bottom: 2.5rem;
+        }
+        .legal-root h2 {
+          font-size: 0.85rem;
+          color: #00d97e;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          margin: 2rem 0 0.75rem;
+        }
+        .legal-root p, .legal-root li {
+          font-size: 0.8rem;
+          line-height: 1.9;
+          color: #7a9a84;
+          margin-bottom: 0.75rem;
+        }
+        .legal-root ul { padding-left: 1.25rem; }
+        .legal-root a { color: #00d97e; }
+        hr {
+          border: none;
+          border-top: 1px solid rgba(0,217,126,0.1);
+          margin: 2rem 0;
+        }
+      `}</style>
+
+      <div className="legal-root">
+        <div className="legal-wrap">
+          <a href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</a>
+
+          <h1>Privacy Policy</h1>
+          <p className="legal-date">Last updated: April 19, 2026</p>
+
+          <p>
+            GetCleanInbox (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or &ldquo;us&rdquo;) operates getcleaninbox.xyz.
+            This policy explains what data we collect, how we use it, and your rights.
+          </p>
+
+          <hr />
+
+          <h2>1. Data We Collect</h2>
+          <ul>
+            <li><strong>Account identity</strong> — your name and email address via Google sign-in (Clerk).</li>
+            <li><strong>Gmail access tokens</strong> — OAuth tokens that allow us to read and manage your Gmail inbox on your behalf. These are stored encrypted in our database.</li>
+            <li><strong>Email metadata</strong> — sender addresses, subject lines, and dates of emails scanned during a session. We do not store email body content.</li>
+            <li><strong>Usage data</strong> — actions taken in the app (e.g. emails deleted, senders unsubscribed) for history and billing purposes.</li>
+          </ul>
+
+          <h2>2. How We Use Your Data</h2>
+          <ul>
+            <li>To scan your Gmail inbox for old unread emails and surface bulk-action suggestions.</li>
+            <li>To execute actions you explicitly approve (delete, unsubscribe).</li>
+            <li>To maintain your subscription and billing status via Stripe.</li>
+            <li>We do not sell, rent, or share your data with third parties for advertising.</li>
+          </ul>
+
+          <h2>3. Gmail API Usage</h2>
+          <p>
+            GetCleanInbox uses the Gmail API to read email metadata and perform actions (delete, send unsubscribe requests) that you explicitly initiate.
+            Our use of Gmail data is limited to providing the in-app features you request.
+            We do not use Gmail data for AI model training, advertising, or any purpose beyond the core product functionality.
+          </p>
+          <p>
+            GetCleanInbox&apos;s use and transfer of information received from Google APIs adheres to the{' '}
+            <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noreferrer">
+              Google API Services User Data Policy
+            </a>
+            , including the Limited Use requirements.
+          </p>
+
+          <h2>4. Data Retention</h2>
+          <ul>
+            <li>Gmail tokens are deleted when you disconnect your Gmail account or delete your account.</li>
+            <li>Action history is retained for 90 days, then purged.</li>
+            <li>You can request deletion of all your data at any time by contacting us.</li>
+          </ul>
+
+          <h2>5. Third-Party Services</h2>
+          <ul>
+            <li><strong>Clerk</strong> — authentication and identity management.</li>
+            <li><strong>Google (Gmail API)</strong> — inbox access.</li>
+            <li><strong>Stripe</strong> — payment processing. We do not store card details.</li>
+            <li><strong>Vercel</strong> — hosting and infrastructure.</li>
+            <li><strong>Neon</strong> — encrypted PostgreSQL database.</li>
+          </ul>
+
+          <h2>6. Security</h2>
+          <p>
+            All data is transmitted over HTTPS. Gmail tokens are stored encrypted at rest.
+            We follow industry-standard security practices to protect your information.
+          </p>
+
+          <h2>7. Your Rights</h2>
+          <p>
+            You can disconnect your Gmail account, delete your account, or request a copy or deletion of your data
+            at any time by emailing us at <a href="mailto:kanmegnea@gmail.com">kanmegnea@gmail.com</a>.
+          </p>
+
+          <h2>8. Contact</h2>
+          <p>
+            Questions? Email us at <a href="mailto:kanmegnea@gmail.com">kanmegnea@gmail.com</a>.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Privacy Policy — GetCleanInbox',
 };
 
+import Link from 'next/link';
+
 export default function PrivacyPage() {
   return (
     <>
@@ -64,7 +66,7 @@ export default function PrivacyPage() {
 
       <div className="legal-root">
         <div className="legal-wrap">
-          <a href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</a>
+          <Link href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</Link>
 
           <h1>Privacy Policy</h1>
           <p className="legal-date">Last updated: April 19, 2026</p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,144 @@
+export const metadata = {
+  title: 'Terms of Service — GetCleanInbox',
+};
+
+export default function TermsPage() {
+  return (
+    <>
+      <style>{`
+        .legal-root {
+          background: #06090f;
+          min-height: 100vh;
+          color: #c8d8cc;
+          font-family: var(--font-space-mono), monospace;
+          padding: 4rem 1.5rem;
+        }
+        .legal-wrap {
+          max-width: 720px;
+          margin: 0 auto;
+        }
+        .legal-logo {
+          font-size: 1rem;
+          color: #00d97e;
+          text-decoration: none;
+          letter-spacing: 0.05em;
+          display: inline-block;
+          margin-bottom: 2.5rem;
+        }
+        .legal-logo span { color: #c8d8cc; }
+        .legal-root h1 {
+          font-family: var(--font-syne), sans-serif;
+          font-size: 1.8rem;
+          font-weight: 700;
+          color: #f0f7f2;
+          margin-bottom: 0.5rem;
+        }
+        .legal-date {
+          font-size: 0.7rem;
+          color: #4a6a54;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          margin-bottom: 2.5rem;
+        }
+        .legal-root h2 {
+          font-size: 0.85rem;
+          color: #00d97e;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          margin: 2rem 0 0.75rem;
+        }
+        .legal-root p, .legal-root li {
+          font-size: 0.8rem;
+          line-height: 1.9;
+          color: #7a9a84;
+          margin-bottom: 0.75rem;
+        }
+        .legal-root ul { padding-left: 1.25rem; }
+        .legal-root a { color: #00d97e; }
+        hr {
+          border: none;
+          border-top: 1px solid rgba(0,217,126,0.1);
+          margin: 2rem 0;
+        }
+      `}</style>
+
+      <div className="legal-root">
+        <div className="legal-wrap">
+          <a href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</a>
+
+          <h1>Terms of Service</h1>
+          <p className="legal-date">Last updated: April 19, 2026</p>
+
+          <p>
+            By using GetCleanInbox (&ldquo;the Service&rdquo;) at getcleaninbox.xyz, you agree to these Terms of Service.
+            Please read them carefully.
+          </p>
+
+          <hr />
+
+          <h2>1. Description of Service</h2>
+          <p>
+            GetCleanInbox is an AI-powered Gmail inbox cleaner that helps users identify, bulk-delete, and
+            unsubscribe from unwanted emails. The Service requires you to connect your Google account and
+            grant Gmail access permissions.
+          </p>
+
+          <h2>2. Eligibility</h2>
+          <p>
+            You must be at least 13 years old to use this Service. By using the Service, you represent that
+            you meet this requirement and that all information you provide is accurate.
+          </p>
+
+          <h2>3. Your Gmail Data</h2>
+          <ul>
+            <li>You grant GetCleanInbox permission to access your Gmail account solely to provide the features you request.</li>
+            <li>All actions (deletions, unsubscribes) require your explicit approval before execution.</li>
+            <li>We do not access, store, or process email content beyond what is necessary to display scan results to you.</li>
+            <li>You can revoke Gmail access at any time via your <a href="https://myaccount.google.com/permissions" target="_blank" rel="noreferrer">Google Account settings</a>.</li>
+          </ul>
+
+          <h2>4. Acceptable Use</h2>
+          <p>You agree not to:</p>
+          <ul>
+            <li>Use the Service to delete emails you do not own or have permission to manage.</li>
+            <li>Attempt to reverse-engineer, scrape, or abuse the Service.</li>
+            <li>Use the Service for any unlawful purpose.</li>
+          </ul>
+
+          <h2>5. Subscription and Billing</h2>
+          <ul>
+            <li>Some features require a paid subscription processed via Stripe.</li>
+            <li>Subscriptions auto-renew until cancelled.</li>
+            <li>You can cancel anytime; access continues until the end of the billing period.</li>
+            <li>We do not offer refunds for partial billing periods.</li>
+          </ul>
+
+          <h2>6. Disclaimer of Warranties</h2>
+          <p>
+            The Service is provided &ldquo;as is&rdquo; without warranties of any kind. We do not guarantee that
+            the Service will be uninterrupted, error-free, or that deleted emails can be recovered.
+            Always review the list of emails before confirming bulk actions.
+          </p>
+
+          <h2>7. Limitation of Liability</h2>
+          <p>
+            To the maximum extent permitted by law, GetCleanInbox shall not be liable for any indirect,
+            incidental, or consequential damages arising from your use of the Service, including accidental
+            deletion of emails.
+          </p>
+
+          <h2>8. Changes to Terms</h2>
+          <p>
+            We may update these Terms at any time. Continued use of the Service after changes constitutes
+            acceptance of the updated Terms.
+          </p>
+
+          <h2>9. Contact</h2>
+          <p>
+            Questions? Email us at <a href="mailto:kanmegnea@gmail.com">kanmegnea@gmail.com</a>.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,6 +2,8 @@ export const metadata = {
   title: 'Terms of Service — GetCleanInbox',
 };
 
+import Link from 'next/link';
+
 export default function TermsPage() {
   return (
     <>
@@ -64,7 +66,7 @@ export default function TermsPage() {
 
       <div className="legal-root">
         <div className="legal-wrap">
-          <a href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</a>
+          <Link href="/" className="legal-logo">get<span>cleaninbox</span>.xyz</Link>
 
           <h1>Terms of Service</h1>
           <p className="legal-date">Last updated: April 19, 2026</p>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -51,7 +51,7 @@ export async function isGmailConnected(userId: string): Promise<boolean> {
   return !!tokenRecord?.accessToken;
 }
 
-export function buildGmailAuthUrl(): string {
+export function buildGmailAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID!,
     redirect_uri: process.env.GOOGLE_REDIRECT_URI!,
@@ -62,6 +62,7 @@ export function buildGmailAuthUrl(): string {
     ].join(' '),
     access_type: 'offline',
     prompt: 'consent',
+    state,
   });
   return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- Adds /privacy — full privacy policy including Gmail API Limited Use disclosure
- Adds /terms — terms of service with Gmail data usage, billing, and liability sections
- Required for Google OAuth consent screen (restricted scope approval)